### PR TITLE
Check file with stat instead of existsSync

### DIFF
--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,8 +1,15 @@
-import { existsSync, readFileSync } from 'fs';
+import { readFileSync, statSync } from 'fs';
 import { format, join, parse, resolve } from 'path';
 import { JSONC } from './helpers';
 import { ConfigLoaderOptions } from './loader';
 
+const fileExistsSync = (path: string) => {
+    try {
+        return statSync(path).isFile();
+    } catch (e) {
+        return false;
+    }
+};
 const fromPairs = (pairs: Array<[keyof any, any]>) => Object.assign({}, ...Array.from(pairs, ([k, v]) => ({ [k]: v })));
 const uniq = <T>(xs: T[]) => Array.from(new Set(xs));
 const { keys } = Object;
@@ -11,7 +18,7 @@ const loadFile = (filePath?: string) => {
     if (!filePath) return {};
     const { dir, name } = parse(filePath);
     const testPaths = uniq([filePath, format({ dir, name, ext: '.json' }), format({ dir, name, ext: '.jsonc' })]);
-    const resolvedPath = testPaths.find(existsSync);
+    const resolvedPath = testPaths.find(fileExistsSync);
     if (!resolvedPath) {
         throw new Error(
             `File path set, but none of the following tested derivations exist:\n${testPaths


### PR DESCRIPTION
Extends the `exists` check to also check whether the path contains a file (and not a directory) to avoid crashing.

Fixes #23