### PR TITLE
Enable nested loaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,39 @@ const config = values({
 }); // type -> { stamp: { type: any, date: Date } };
 ```
 
+Custom loaders can also return an object that contains nested loaders. Meaning you can have a custom loader that 
+loads a value from storage and based on that value returns another objects (or an array of objects) that themselves may contain loaders.
+
+This can be particularly useful for arrays of connection strings that may contain sensitive information like passwords. This will give you type-safe array of objects, while still supporting hidden loaders.
+
+```typescript
+// env.json
+// {
+//   "PASSWORD": "pwd",
+//   "HOSTS": "host1,host2"
+// }
+const schema = {
+  connections: loader.custom(x => {
+    return x.split(',').map(host => ({
+      host,
+      password: loader.string.hidden('PASSWORD'),      
+    }))
+  })('HOSTS')
+}
+
+console.log(safeValues(schema));
+// [
+//     {
+//         "host": "host1",
+//         "foo": "[redacted]"
+//     },
+//     {
+//         "host": "host2",
+//         "foo": "[redacted]"
+//     }
+// ]
+```
+
 ## Best practices
  - Always **use flat structure** in JSON files (create logical hierarchy in your app when building config with loader)
  - For config keys, **use `CAPITALIZED_WITH_UNDERSCORES` case**, as is conventional for env variables

--- a/src/lib/polishers.ts
+++ b/src/lib/polishers.ts
@@ -19,7 +19,7 @@ const isLoadedValue = (x: any) => Object.keys(x || {}).includes('__CONFIGURU_LEA
 
 const mapConfig = (fn: (v: LoadedValue<any, any>) => any) => (val: any): any => {
     if (isLoadedValue(val)) {
-        return fn(val);
+        return mapConfig(fn)(fn(val));
     }
     if (Array.isArray(val)) {
         return val.map(mapConfig(fn));

--- a/src/test/loader.test.ts
+++ b/src/test/loader.test.ts
@@ -16,10 +16,29 @@ describe('loader', () => {
     const schema = {
         foo: string('FOO'),
         stamp: custom((foo) => `${foo}bar`)('FOO'),
+        expanded: custom((x) => {
+            return x.split('').map((letter: string) => ({ s: letter, foo: string('FOO') }));
+        })('FOO'),
     };
-    const { foo, stamp } = values(schema);
+    const { foo, stamp, expanded } = values(schema);
     expect(foo).toMatchInlineSnapshot('"foo"');
     expect(stamp).toMatchInlineSnapshot('"foobar"');
+    expect(expanded).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "foo": "foo",
+            "s": "f",
+          },
+          Object {
+            "foo": "foo",
+            "s": "o",
+          },
+          Object {
+            "foo": "foo",
+            "s": "o",
+          },
+        ]
+    `);
 });
 
 describe('atomLoader', () => {


### PR DESCRIPTION
## What does this PR do?
Adds support for nested value loaders. Meaning you can have a `custom()` loader that loads a value from storage and _based on that value_ returns another (or multitude of) objects that themselves may contain loaders.

This is particularly useful for arrays of connection strings that may contain sensitive information like passwords.

env.json
```
{
  "PASSWORD": "pwd",
  "HOSTS": "host1,host2"
}
```
```typescript
const { string, custom } = createLoader(/* ... */);

const schema = {
  connections: custom(x => {
    return x.split(',').map(host => ({
      host,
      password: string.hidden('PASSWORD'),      
    }))
  })('HOSTS')
}
```
This will give you type-safe array of objects, while still enabling hidden loaders 

```jsonc
// safeValues(schema);
[
    {
    "host": "host1",
    "foo": "[redacted]"
    },
    {
    "host": "host2",
    "foo": "[redacted]"
    }
]
```