### PR TITLE
🐛 Remove engines from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
     "Jaroslav Šmolík <grissius@gmail.com>"
   ],
   "main": "./dist/index.js",
-  "engines": {
-    "node": "^10.14.0"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/AckeeCZ/configuru"


### PR DESCRIPTION
Configuru does not do anything special to require a specific version of
node. Any supported will work AFAIK.

> If you specify an “engines” field, then npm will require that “node”
> be somewhere on that list. If “engines” is omitted, then npm will
> just assume that it works on node.

Removing seemd to be a reasonable soltution to #24

See: https://docs.npmjs.com/files/package.json#engines
Related: #24