### PR TITLE
🚚 Rename safeValues to maskedValues

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { createLoader } from './lib/loader'
-export { values, safeValues } from './lib/polishers'
+export { values, maskedValues } from './lib/polishers'

--- a/src/lib/polishers.ts
+++ b/src/lib/polishers.ts
@@ -51,6 +51,6 @@ const mapConfig =
 export const values = mapConfig(x => x.value) as <T extends Record<any, any>>(
   config: T
 ) => Values<T>
-export const safeValues = mapConfig(x =>
+export const maskedValues = mapConfig(x =>
   x.hidden ? anonymize(x.rawValue) : x.value
 ) as <T extends Record<any, any>>(config: T) => AnonymousValues<T>


### PR DESCRIPTION
### PR addresses:
- Renames `safeValues` function to `maskedValues` based on standard way how to name `hidden values` in configurations / env vars

Fixes #16 
