### PR TITLE
✨ Increased transparency by always using env var names

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,19 +45,20 @@ npm install configuru
 4. Create a configuration module (e.g. `config.ts`)
 
 ```typescript
-import { createLoader, values } from 'configuru'
+import { createLoader, schema } from 'configuru'
 
 // create loader that cascades overrides and creates a config storage
 const loader = createLoader()
-
-// Pass configuration schema to `values` transformer to get configuration
-export default values({
+// Pass configuration structure to loader transformer to get configuration schema
+const config = loader({
   server: {
-    // use loader accessors, place them in custom structure
+    // use schema definition, place them in custom structure
     // loader parses correct type from store
-    port: loader.number('SERVER_PORT'),
+    port: schema.number('SERVER_PORT'),
   },
 })
+// Use loaded values
+export default config.values()
 ```
 
 5. Use your configuration params throughout your app

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { createLoader } from './lib/loader'
-export { values, maskedValues } from './lib/polishers'
+export { schema } from './lib/schema'

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,0 +1,61 @@
+import { parseBool } from './helpers'
+
+export type TransformFn<T> = (x: any) => T
+
+export type ValueDefinition<T> = {
+  key?: string
+  hidden?: boolean
+  nullable?: boolean
+  transform: TransformFn<T>
+  isCustom?: boolean
+  __CONFIGURU_LEAF: true
+}
+
+export type SchemaDef = {
+  [key: string]: ValueDefinition<any> | SchemaDef
+}
+
+const register =
+  <T, K extends string>(
+    transform: TransformFn<T>,
+    hidden: boolean,
+    nullable: boolean,
+    isCustom: boolean
+  ) =>
+  <S extends K>(key?: S): ValueDefinition<T> => {
+    return {
+      key,
+      hidden,
+      nullable,
+      transform,
+      isCustom,
+      __CONFIGURU_LEAF: true,
+    }
+  }
+
+export const createSchemaFn = <T>(transform: (x: any) => T, isCustom = false) =>
+  Object.assign(register<T, string>(transform, false, false, isCustom), {
+    hidden: Object.assign(
+      register<T, string>(transform, true, false, isCustom),
+      {
+        nullable: register<T, string>(transform, true, true, isCustom),
+      }
+    ),
+    nullable: Object.assign(
+      register<T, string>(transform, false, true, isCustom),
+      {
+        hidden: register<T, string>(transform, true, true, isCustom),
+      }
+    ),
+  })
+
+export const schema = {
+  number: createSchemaFn(Number, false),
+  string: createSchemaFn(String, false),
+  bool: createSchemaFn(parseBool, false),
+  json: createSchemaFn(JSON.parse, false),
+  custom: <T>(fn: (x: any) => T) => createSchemaFn(fn, true),
+}
+
+export const isValueDefinition = (x: any): x is ValueDefinition<any> =>
+  Object.keys(x ?? {}).includes('__CONFIGURU_LEAF')

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -6,7 +6,7 @@ import { ConfigLoaderOptions } from './loader'
 const fileExistsSync = (path: string) => {
   try {
     return statSync(path).isFile()
-  } catch (_error) {
+  } catch {
     return false
   }
 }
@@ -45,7 +45,7 @@ const loadFile = (filePath?: string) => {
   try {
     return JSONC.parse(readFileSync(resolvedPath, 'utf-8'))
   } catch (_error) {
-    throw new Error(`Invalid config file in ${resolvedPath}\n`)
+    throw new Error(`Invalid config file in ${resolvedPath}`)
   }
 }
 

--- a/src/test/sandbox/base.jsonc
+++ b/src/test/sandbox/base.jsonc
@@ -1,0 +1,6 @@
+{
+  "string": "string",
+  "number": 42,
+  "boolean": false,
+  "null": null
+}

--- a/wiki/best-practices.md
+++ b/wiki/best-practices.md
@@ -6,6 +6,7 @@
 - Keep your configuration interface **minimal**. If you don't need to configure parameter for different environments, use constant parameter without loader.
 - Even though you can use plain `JSON` for config values, **prefer `JSONc`** and add comments to your variables.
 - **Keep your `.env.jsonc` well structured and well documented**. Setting up the configuration should not require thorough prior knowledge of the implementation.
+- For simple flat applications without modularization, use flat config structure with automatic parameter names
 
 ### When to use placeholder, when default value?
 


### PR DESCRIPTION
### PR addresses:
- Reworks Configuru API to allow empty name definition `SERVER_PORT: schema.string()`
- Adds `reload` function for automatic config reload based on previous settings

New example usage viz docs.

Fixes #52
REDMIME-96040
